### PR TITLE
fix windows build. separate example

### DIFF
--- a/examples/build.zig
+++ b/examples/build.zig
@@ -1,0 +1,39 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+    const maybe_override_registry = b.option([]const u8, "override-registry", "Override the path to the Vulkan registry used for the examples");
+
+    const exe = b.addExecutable(.{
+        .name = "openxr_test",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("test.zig"),
+            .target = target,
+            .link_libc = true,
+            .optimize = optimize,
+        }),
+    });
+    b.installArtifact(exe);
+    if (b.option([]const u8, "libdir", "The directory where openxr_loader.lib is located")) |libdir| {
+        exe.addLibraryPath(.{ .cwd_relative = libdir });
+    }
+    exe.linkSystemLibrary("openxr_loader");
+
+    const registry_path: std.Build.LazyPath = if (maybe_override_registry) |override_registry|
+        .{ .cwd_relative = override_registry }
+    else
+        b.path("xr.xml");
+
+    const openxr = b.dependency("openxr_zig", .{
+        .registry = registry_path.getPath(b),
+    }).module("openxr-zig");
+
+    exe.root_module.addImport("openxr", openxr);
+
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+
+    const run_step = b.step("run-openxr", "Run the openxr example");
+    run_step.dependOn(&run_cmd.step);
+}

--- a/examples/build.zig.zon
+++ b/examples/build.zig.zon
@@ -1,0 +1,11 @@
+.{
+    .name = .openxr_zig_examples,
+    .version = "0.1.0",
+    .fingerprint = 0x2c133056e63a1413,
+    .dependencies = .{
+        .openxr_zig = .{
+            .path = "..",
+        },
+    },
+    .paths = .{""},
+}

--- a/generator/openxr/render.zig
+++ b/generator/openxr/render.zig
@@ -14,7 +14,7 @@ const preamble =
     \\const builtin = @import("builtin");
     \\const root = @import("root");
     \\
-    \\pub const openxr_call_conv: std.builtin.CallingConvention = if (builtin.os.tag == .windows and builtin.cpu.arch == .i386)
+    \\pub const openxr_call_conv: std.builtin.CallingConvention = if (builtin.os.tag == .windows and builtin.cpu.arch == .x86)
     \\        .Stdcall
     \\    else if (builtin.abi == .android and (builtin.cpu.arch.isARM() or builtin.cpu.arch.isThumb()) and builtin.Target.arm.featureSetHas(builtin.cpu.features, .has_v7) and builtin.cpu.arch.ptrBitWidth() == 32)
     \\        // On Android 32-bit ARM targets, OpenXR functions use the "hardfloat"


### PR DESCRIPTION
Hello.

I created a fix because there was an issue with referencing openxr-zig with build.zig.zon and using it.

The example build is integrated with the generation of xr.zig, and an error occurs when linking with "openxr_loader".
I separated it into examples/build.zig.

Changed i386 to x86.

It worked with native/x64/release/binopenxr_loader.dll and native/x64/release/lib/openxr_loader.lib
from [OpenXR.Loader.1.1.50.nupkg](https://github.com/KhronosGroup/OpenXR-SDK/releases/tag/release-1.1.50).

```
> .\zig-out\bin\openxr_test.exe
10/08 22:50:33.621 {DEBUG}   [OXR] xrNegotiateLoaderRuntimeInterface loading 1.1.46
system 23:
  vendor Id: 4294955582
  systemName: Meta Quest 3
  gfx
    max swapchain image resolution: 4096x4096
    max layer count: 16
  tracking
    orientation tracking: 1
    positional tracking: 1

error: GraphicsDeviceInvalid
```
